### PR TITLE
Feat/listener service

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,10 +30,13 @@ repositories {
     mavenCentral()
 }
 
+extra["springCloudVersion"] = "2020.0.3"
+
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-amqp")
+    implementation("org.springframework.cloud:spring-cloud-starter-openfeign")
     implementation("com.fasterxml.jackson.core:jackson-databind")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.testcontainers:mysql:1.15.3")
@@ -50,6 +53,12 @@ dependencies {
         exclude(group = "org.junit.vintage", module = "junit-vintage-engine")
     }
     runtimeOnly("mysql:mysql-connector-java")
+}
+
+dependencyManagement {
+    imports {
+        mavenBom("org.springframework.cloud:spring-cloud-dependencies:${property("springCloudVersion")}")
+    }
 }
 
 tasks.withType<KotlinCompile> {

--- a/src/main/kotlin/com/quicoment/demo/DemoApplication.kt
+++ b/src/main/kotlin/com/quicoment/demo/DemoApplication.kt
@@ -2,8 +2,10 @@ package com.quicoment.demo
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
+import org.springframework.cloud.openfeign.EnableFeignClients
 
 @SpringBootApplication
+@EnableFeignClients
 class DemoApplication
 
 fun main(args: Array<String>) {

--- a/src/main/kotlin/com/quicoment/demo/dto/QueueDelete.kt
+++ b/src/main/kotlin/com/quicoment/demo/dto/QueueDelete.kt
@@ -1,0 +1,3 @@
+package com.quicoment.demo.dto
+
+data class QueueDelete(val QueueName: String)

--- a/src/main/kotlin/com/quicoment/demo/dto/QueueRequest.kt
+++ b/src/main/kotlin/com/quicoment/demo/dto/QueueRequest.kt
@@ -1,0 +1,3 @@
+package com.quicoment.demo.dto
+
+data class QueueRequest(val QueueName: String, val DirectRoutingKey: String, val TopicRoutingKey: String)

--- a/src/main/kotlin/com/quicoment/demo/service/ListenerService.kt
+++ b/src/main/kotlin/com/quicoment/demo/service/ListenerService.kt
@@ -1,5 +1,6 @@
 package com.quicoment.demo.service
 
+import com.quicoment.demo.dto.QueueDelete
 import com.quicoment.demo.dto.QueueRequest
 import org.springframework.cloud.openfeign.FeignClient
 import org.springframework.web.bind.annotation.DeleteMapping
@@ -11,5 +12,5 @@ interface ListenerService {
     fun newQueueListener(requestBody: QueueRequest)
 
     @DeleteMapping("/queues")
-    fun deleteQueueListener(QueueName: String)
+    fun deleteQueueListener(requestBody: QueueDelete)
 }

--- a/src/main/kotlin/com/quicoment/demo/service/ListenerService.kt
+++ b/src/main/kotlin/com/quicoment/demo/service/ListenerService.kt
@@ -1,0 +1,15 @@
+package com.quicoment.demo.service
+
+import com.quicoment.demo.dto.QueueRequest
+import org.springframework.cloud.openfeign.FeignClient
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.PostMapping
+
+@FeignClient(name = "mq-client", url = "http://localhost:9090") // TODO: real url injection from property
+interface ListenerService {
+    @PostMapping("/queues")
+    fun newQueueListener(requestBody: QueueRequest)
+
+    @DeleteMapping("/queues")
+    fun deleteQueueListener(QueueName: String)
+}

--- a/src/main/kotlin/com/quicoment/demo/service/MQService.kt
+++ b/src/main/kotlin/com/quicoment/demo/service/MQService.kt
@@ -1,5 +1,6 @@
 package com.quicoment.demo.service
 
+import com.quicoment.demo.dto.QueueDelete
 import com.quicoment.demo.dto.QueueRequest
 import org.springframework.amqp.core.*
 import org.springframework.beans.factory.annotation.Autowired
@@ -30,9 +31,9 @@ class MQService(
         return QueueRequest(queueName, registerExchangeName, likeExchangeName)
     }
 
-    fun deletePostQueue(id: String): String {
+    fun deletePostQueue(id: String): QueueDelete {
         val queueName = "${queueDomain}.post.${id}"
         rabbitAdmin.deleteQueue(queueName)
-        return queueName
+        return QueueDelete(queueName)
     }
 }

--- a/src/main/kotlin/com/quicoment/demo/service/MQService.kt
+++ b/src/main/kotlin/com/quicoment/demo/service/MQService.kt
@@ -1,5 +1,6 @@
 package com.quicoment.demo.service
 
+import com.quicoment.demo.dto.QueueRequest
 import org.springframework.amqp.core.*
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
@@ -14,16 +15,24 @@ class MQService(
     @Autowired private val commentLikeExchange: TopicExchange,
     @Value("\${rabbitmq.queue-name-domain}") private val queueDomain: String) {
 
-    fun declarePostQueue(id: String) {
-        val newQueue = Queue("${queueDomain}.post.${id}")
+    fun declarePostQueue(id: String): QueueRequest {
+        val queueName = "${queueDomain}.post.${id}"
+        val newQueue = Queue(queueName)
         rabbitAdmin.declareQueue(newQueue)
+
+        val registerExchangeName = "post.${id}.comment"
         rabbitAdmin.declareBinding(
-            BindingBuilder.bind(newQueue).to(commentRegisterExchange).with("post.${id}.comment"))
+            BindingBuilder.bind(newQueue).to(commentRegisterExchange).with(registerExchangeName))
+
+        val likeExchangeName = "post.${id}.comment.#"
         rabbitAdmin.declareBinding(
-            BindingBuilder.bind(newQueue).to(commentLikeExchange).with("post.${id}.comment.#"))
+            BindingBuilder.bind(newQueue).to(commentLikeExchange).with(likeExchangeName))
+        return QueueRequest(queueName, registerExchangeName, likeExchangeName)
     }
 
-    fun deletePostQueue(id: String): Boolean {
-        return rabbitAdmin.deleteQueue("${queueDomain}.post.${id}")
+    fun deletePostQueue(id: String): String {
+        val queueName = "${queueDomain}.post.${id}"
+        rabbitAdmin.deleteQueue(queueName)
+        return queueName
     }
 }

--- a/src/main/kotlin/com/quicoment/demo/service/PostService.kt
+++ b/src/main/kotlin/com/quicoment/demo/service/PostService.kt
@@ -47,7 +47,7 @@ class PostService(
     fun deletePost(id: Long) {
         postRepository.findById(id).orElseThrow { NoSuchResourceException(ErrorCase.NO_SUCH_POST.getMessage()) }
             .let { postRepository.delete(it) }
-        val queueName = mqService.deletePostQueue(id.toString())
-        listenerService.deleteQueueListener(queueName)
+        val queueDelete = mqService.deletePostQueue(id.toString())
+        listenerService.deleteQueueListener(queueDelete)
     }
 }

--- a/src/main/kotlin/com/quicoment/demo/service/PostService.kt
+++ b/src/main/kotlin/com/quicoment/demo/service/PostService.kt
@@ -6,7 +6,6 @@ import com.quicoment.demo.common.error.custom.NoSuchResourceException
 import com.quicoment.demo.domain.Post
 import com.quicoment.demo.dto.PostResponse
 import com.quicoment.demo.repository.PostRepository
-import org.springframework.amqp.core.*
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -15,13 +14,15 @@ import org.springframework.transaction.annotation.Transactional
 @Transactional(readOnly = true)
 class PostService(
     @Autowired private val postRepository: PostRepository,
-    @Autowired private val mqService: MQService) {
+    @Autowired private val mqService: MQService,
+    @Autowired private val listenerService: ListenerService) {
 
     @Transactional
     fun savePost(post: Post): Long {
         val postId = postRepository.save(post).toResponseDto().id
             ?: throw FailCreateResourceException(ErrorCase.SAVE_POST_FAIL.getMessage())
-        mqService.declarePostQueue(postId.toString())
+        val queueRequest = mqService.declarePostQueue(postId.toString())
+        listenerService.newQueueListener(queueRequest)
         return postId
     }
 
@@ -46,6 +47,7 @@ class PostService(
     fun deletePost(id: Long) {
         postRepository.findById(id).orElseThrow { NoSuchResourceException(ErrorCase.NO_SUCH_POST.getMessage()) }
             .let { postRepository.delete(it) }
-        mqService.deletePostQueue(id.toString())
+        val queueName = mqService.deletePostQueue(id.toString())
+        listenerService.deleteQueueListener(queueName)
     }
 }


### PR DESCRIPTION
일단 golang 포트 9090 열어서 테스트 해봤는데, golang에서 exchange가 하나 디폴트로 띄워지는데, 포스트 생성시에 exchange 2개씩 생성되고, 라우팅 키도 필요한 것 같아 RequestBody 를 QueueRequest 클래스 형식으로 바꿨습니다. (이 부분은 golang 코드 수정한 것도 올리겠습니다)

음 그리고 큐 삭제시에도 저쪽 서버에 알려줘야 될까요? 아님 알아서 리스닝이 끊어지려나요..
